### PR TITLE
Enable standard google-java-format and reformat NullSpecTest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,6 @@ clean.doFirst {
 
 spotless {
     java {
-        googleJavaFormat().aosp()
+        googleJavaFormat()
     }
 }

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -19,18 +19,12 @@ import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
 public class NullSpecTest extends CheckerFrameworkPerDirectoryTest {
-    public NullSpecTest(List<File> testFiles) {
-        super(
-                testFiles,
-                NullSpecChecker.class,
-                "NullSpec",
-                "-Anomsgtext",
-                "-Astubs=stubs/",
-                "-nowarn");
-    }
+  public NullSpecTest(List<File> testFiles) {
+    super(testFiles, NullSpecChecker.class, "NullSpec", "-Anomsgtext", "-Astubs=stubs/", "-nowarn");
+  }
 
-    @Parameters
-    public static String[] getTestDirs() {
-        return new String[] {"nullspec-common"};
-    }
+  @Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"nullspec-common"};
+  }
 }


### PR DESCRIPTION
Follow-up to https://github.com/jspecify/nullness-checker-for-checker-framework/commit/a9bef19df9fea4ecdfbe53a2b9ad33a9cf4e683b and https://github.com/jspecify/nullness-checker-for-checker-framework/pull/2 .
NullSpecTest was not reformatted with google-java-format. Update the build file to enforce 2-space formatting.