### PR TITLE
Restrict exception parameters to non-null values.

### DIFF
--- a/src/main/java/com/google/jspecify/nullness/NullSpecTransfer.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecTransfer.java
@@ -21,7 +21,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.toList;
-import static javax.lang.model.element.ElementKind.EXCEPTION_PARAMETER;
 import static org.checkerframework.dataflow.expression.JavaExpression.fromNode;
 import static org.checkerframework.framework.flow.CFAbstractStore.canInsertJavaExpression;
 import static org.checkerframework.framework.type.AnnotatedTypeMirror.createType;
@@ -55,7 +54,6 @@ import org.checkerframework.dataflow.cfg.node.BinaryOperationNode;
 import org.checkerframework.dataflow.cfg.node.EqualToNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
-import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.NotEqualNode;
@@ -356,17 +354,6 @@ final class NullSpecTransfer extends CFAbstractTransfer<CFValue, NullSpecStore, 
 
     return new ConditionalTransferResult<>(
         result.getResultValue(), thenStore, elseStore, storeChanged);
-  }
-
-  @Override
-  public TransferResult<CFValue, NullSpecStore> visitLocalVariable(
-      LocalVariableNode node, TransferInput<CFValue, NullSpecStore> input) {
-    TransferResult<CFValue, NullSpecStore> result = super.visitLocalVariable(node, input);
-    if (node.getElement().getKind() == EXCEPTION_PARAMETER
-        && input.getRegularStore().getValue(node) == null) {
-      setResultValueToNonNull(result);
-    }
-    return result;
   }
 
   private boolean refineFutureGetEnclosingClassFromIsAnonymousClass(


### PR DESCRIPTION
Of course the caught exception is already non-null, so all
this does is forbid users from manually assigning null to an exception
parameter.

This fixes a false positive demonstrated by
https://github.com/jspecify/jspecify/commit/fc8a3ed723bc0c69bcaa2e88e1726d489a501a7f

This commit undoes 23cd183d57ec972058753d2860bd14aa907378e0 (though I
didn't literally revert it, since
49c18e2ab72da45f05f6c3b14b2db15ab5972342 seemed like a nice change to
keep). It also undoes de78501ddf64c358d45a2737df4c41ad4394bd20 (which
was itself a replacement for 661784038fed4987478d3bcb1d070b808078245b),
as there's no longer a need for special handling for union types in
source code after this commit fixes things more generally.

I'm not entirely sure exactly why my various attempts at handling
exception parameters more correctly have failed. But I just sunk some
more time into this after sinking too much time into it already in the
past, so I'm giving up.