### PR TITLE
Work around infinite recursion in `applyQualifierParameterDefaults`, maybe.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ test {
     inputs.files("${rootDir}/tests/minimal")
     maxHeapSize = "4096m"
     jvmArgs '-XX:MaxMetaspaceSize=1024m'
+    forkEvery 1
 }
 
 task jspecifySamplesTest(type: Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ tasks.withType(Test) {
 
 test {
     include '**/NullSpecTest$Minimal.class'
+    systemProperty 'emit.test.debug', 'true'
 
     inputs.files("${rootDir}/tests/minimal")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ test {
     systemProperty 'emit.test.debug', 'true'
 
     inputs.files("${rootDir}/tests/minimal")
-    maxHeapSize = "4096m"
+    maxHeapSize = "5096m"
     jvmArgs '-XX:MaxMetaspaceSize=1024m'
     forkEvery 1
 }
@@ -110,7 +110,8 @@ task ensureCheckerFrameworkBuilt() {
         exec {
             workingDir cfHome
             executable './gradlew'
-            args = ['cloneAndBuildDependencies']
+            // hmm bad in general but maybe good for CI? would be nice to propagate this to annotation-tools and jspecify, but at least those are smaller
+            args = ['--no-daemon', 'cloneAndBuildDependencies']
         }
 
         // We test using some modified samples in a different branch of the jspecify repo, so we want to change to that branch.

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ test {
     systemProperty 'emit.test.debug', 'true'
 
     inputs.files("${rootDir}/tests/minimal")
+    maxHeapSize = "4096m"
+    jvmArgs '-XX:MaxMetaspaceSize=1024m'
 }
 
 task jspecifySamplesTest(type: Test) {

--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -1356,7 +1356,7 @@ final class NullSpecAnnotatedTypeFactory
   }
 
   @Override
-  protected void applyQualifierParameterDefaults(Tree tree, AnnotatedTypeMirror type) {
+  protected void applyQualifierParameterDefaults(Element elt, AnnotatedTypeMirror type) {
     /*
      * The supermethod implements support for HasQualifierParameter, which we don't use. That's
      * fortunate, as the supermethod can trigger infinite recursion (almost certainly because of our

--- a/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
+++ b/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java
@@ -1355,6 +1355,15 @@ final class NullSpecAnnotatedTypeFactory
      */
   }
 
+  @Override
+  protected void applyQualifierParameterDefaults(Tree tree, AnnotatedTypeMirror type) {
+    /*
+     * The supermethod implements support for HasQualifierParameter, which we don't use. That's
+     * fortunate, as the supermethod can trigger infinite recursion (almost certainly because of our
+     * hacky changes to stub-file parsing) -- though so far only in our GitHub Actions CI?
+     */
+  }
+
   private static TypeParameterElement correspondingTypeParameter(AnnotatedWildcardType type) {
     /*
      * type.getTypeVariable() is not available in all cases that we need.

--- a/src/test/java/tests/NullSpecTest.java
+++ b/src/test/java/tests/NullSpecTest.java
@@ -36,6 +36,7 @@ public class NullSpecTest {
           "-Anomsgtext",
           "-AcheckImpl",
           "-AsuppressWarnings=conditional.type.incompatible");
+      checkerOptions.remove(checkerOptions.size() - 1); // remove -AcheckJavaParserVisitor
     }
 
     @Parameters
@@ -54,6 +55,7 @@ public class NullSpecTest {
           "-Anomsgtext",
           "-AcheckImpl",
           "-AsuppressWarnings=conditional.type.incompatible");
+      checkerOptions.remove(checkerOptions.size() - 1); // remove -AcheckJavaParserVisitor
     }
 
     @Parameters
@@ -78,6 +80,7 @@ public class NullSpecTest {
           "-AcheckImpl",
           "-AsuppressWarnings=conditional.type.incompatible",
           "-Astrict");
+      checkerOptions.remove(checkerOptions.size() - 1); // remove -AcheckJavaParserVisitor
     }
 
     @Parameters


### PR DESCRIPTION
I'm testing this as a PR, since I haven't been able to reproduce the problem
locally.

(I should probably point out that the tests have gotten far enough to reach the
infinite recursion only once in the CI. So for all I know, the problem might
just occur pseudorandomly....)

---

Work around infinite recursion in `applyQualifierParameterDefaults`.

The infinite recursion is almost certainly caused by the hacky changes
I made a while back and described in
https://github.com/jspecify/checker-framework/issues/11

The repeating part of the stack is:

```
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:2875)
      	at org.checkerframework.framework.stub.AnnotationFileParser.processFakeOverride(AnnotationFileParser.java:1853)
      	at org.checkerframework.framework.stub.AnnotationFileParser.processTypeDecl(AnnotationFileParser.java:860)
      	at org.checkerframework.framework.stub.AnnotationFileParser.processCompilationUnit(AnnotationFileParser.java:685)
      	at org.checkerframework.framework.stub.AnnotationFileParser.processStubUnit(AnnotationFileParser.java:661)
      	at org.checkerframework.framework.stub.AnnotationFileParser.process(AnnotationFileParser.java:650)
      	at org.checkerframework.framework.stub.AnnotationFileParser.parseStubFile(AnnotationFileParser.java:604)
      	at org.checkerframework.framework.stub.AnnotationFileParser.parseJdkFileAsStub(AnnotationFileParser.java:580)
      	at org.checkerframework.framework.stub.AnnotationFileElementTypes.parseJarEntry(AnnotationFileElementTypes.java:575)
      	at org.checkerframework.framework.stub.AnnotationFileElementTypes.parseEnclosingClass(AnnotationFileElementTypes.java:502)
      	at org.checkerframework.framework.stub.AnnotationFileElementTypes.getDeclAnnotation(AnnotationFileElementTypes.java:374)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getDeclAnnotations(AnnotatedTypeFactory.java:3703)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getDeclAnnotation(AnnotatedTypeFactory.java:3631)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getDeclAnnotation(AnnotatedTypeFactory.java:3553)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getSupportedAnnotationsInElementAnnotation(AnnotatedTypeFactory.java:4108)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getQualifierParameterHierarchies(AnnotatedTypeFactory.java:4066)
      	at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.applyQualifierParameterDefaults(GenericAnnotatedTypeFactory.java:1889)
      	at org.checkerframework.framework.type.GenericAnnotatedTypeFactory.addComputedTypeAnnotations(GenericAnnotatedTypeFactory.java:1984)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:1092)
      	at org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:2875)
```